### PR TITLE
Fix field name mismatch in preview controller

### DIFF
--- a/app/javascript/controllers/previsualizacion_controller.js
+++ b/app/javascript/controllers/previsualizacion_controller.js
@@ -34,7 +34,7 @@ export default class extends Controller {
       const esApertura = celda.dataset.aperturaAutorizada === 'true'
       
       const inputHoras = celda.querySelector('input[name*="[horas_trabajadas]"]')
-      const inputComp = celda.querySelector('input[name*="[horas_complementarias_pagadas]"]')
+      const inputComp = celda.querySelector('input[name*="[horas_comp_pagadas]"]')
       const checkPagoDoble = celda.querySelector('input[name*="[pago_doble]"]')
       const selectAusencia = celda.querySelector('select[name*="[tipo_ausencia_id]"]')
       

--- a/test/fixtures/entrada_diaria.yml
+++ b/test/fixtures/entrada_diaria.yml
@@ -7,7 +7,7 @@ one:
   tipo_ausencia: one
   horas_ausencia: 9.99
   pago_doble_marcado: false
-  horas_complementarias_pagadas: 9.99
+  horas_comp_pagadas: 9.99
 
 two:
   trabajador: two
@@ -16,4 +16,4 @@ two:
   tipo_ausencia: two
   horas_ausencia: 9.99
   pago_doble_marcado: false
-  horas_complementarias_pagadas: 9.99
+  horas_comp_pagadas: 9.99


### PR DESCRIPTION
## Summary
- fix Stimulus selector for complementaria hours
- update fixture field to match schema

## Testing
- `bundle exec rails test` *(fails: rbenv: version `3.3.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6875992f76208327bbcc8b6344ddfa5a