### PR TITLE
Fix back button style

### DIFF
--- a/app/views/fichajes/semanal.html.erb
+++ b/app/views/fichajes/semanal.html.erb
@@ -8,7 +8,7 @@
 <div class="container content-box">
   <div class="page-header">
     <h1>Confirmación Semanal</h1>
-    <%= link_to "« Volver al Menú", root_path, class: "nav-link-admin-button" %>
+    <%= link_to "« Volver al Menú", root_path, class: "btn btn-secondary" %>
   </div>
 
   <div class="week-selector d-flex justify-content-between align-items-center mb-3">
@@ -109,6 +109,6 @@
     </table>
   </form>
   <div class="footer-nav">
-       <%= link_to '« Volver al Menú', root_path, class: 'nav-link-admin-button' %>
+       <%= link_to '« Volver al Menú', root_path, class: 'btn btn-secondary' %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- use Bootstrap `btn` styling for "Volver al Menú" links in the weekly form

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_6875a4d9c84c83279366c3066b33996e