### PR TITLE
Improve absence select UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+\nvendor/bundle/

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -72,3 +72,15 @@ form label {
   font-size: 0.85rem;
 }
 
+/* Ancho y estilo de las columnas diarias */
+.schedule-table .day-cell {
+  width: 8rem;
+}
+
+/* Centrado del botón Guardar */
+.acciones-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+

--- a/app/views/fichajes/semanal.html.erb
+++ b/app/views/fichajes/semanal.html.erb
@@ -78,7 +78,7 @@
                       options_for_select(@tipos_ausencia, entrada_dia&.tipo_ausencia_id),
                       include_blank: '---',
                       class: "form-select form-select-sm",
-                      data: { action: "change->previsualizacion#recalcular blur->cell#showAbbreviations focus->cell#showFullNames",
+                      data: { action: "change->cell#toggleAusenciaHoras change->cell#showAbbreviations change->previsualizacion#recalcular blur->cell#showAbbreviations focus->cell#showFullNames",
                               cell_target: 'tipoAusenciaSelect' } %>
                   <div class="mt-1 d-none" data-cell-target="horasAusenciaWrapper">
                     <input type="number" name="dias[<%= fecha %>][horas_ausencia]" value="<%= entrada_dia&.horas_ausencia %>" class="form-control form-control-sm" step="0.25" data-action="change->previsualizacion#recalcular">


### PR DESCRIPTION
## Summary
- toggle absence hours on change and show abbreviations immediately
- add width for day columns and center "Guardar" button
- ignore `vendor/bundle`

## Testing
- `bundle exec rails test` *(fails: table "bolsa_horas_saldos" has no columns)*

------
https://chatgpt.com/codex/tasks/task_e_6875a74a12fc8327b4866931a04794a4