### PR TITLE
Fix label size for hour balance forms

### DIFF
--- a/app/views/admin/festivos/_form.html.erb
+++ b/app/views/admin/festivos/_form.html.erb
@@ -26,7 +26,7 @@
         <%= form.label :descripcion, class: "form-label" %>
         <%= form.text_field :descripcion, class: "form-control", placeholder: "Ej: San Valero (Festivo Local Zaragoza)" %>
       </div>
-      <div class="mb-3 form-check form-switch fs-5">
+      <div class="mb-3 form-check form-switch">
         <%= form.check_box :apertura_autorizada, class: 'form-check-input', role: 'switch' %>
         <%= form.label :apertura_autorizada, '¿Es una Apertura Autorizada?', class: 'form-check-label fw-bold' %>
         <div class="form-text mt-1">

--- a/app/views/admin/tipo_ausencias/_form.html.erb
+++ b/app/views/admin/tipo_ausencias/_form.html.erb
@@ -48,7 +48,7 @@
       </div>
 
       <%# 3. ¿Es Retribuida? %>
-      <div class="mb-4 form-check form-switch fs-5">
+      <div class="mb-4 form-check form-switch">
         <%= form.check_box :es_retribuida, class: 'form-check-input', role: 'switch' %>
         <%= form.label :es_retribuida, '¿Es Retribuida?', class: 'form-check-label fw-bold' %>
         <div class="form-text mt-1">Si está marcado, las horas de ausencia cuentan como trabajadas para la jornada anual.</div>
@@ -75,7 +75,7 @@
       </div>
 
       <%# 5. ¿Genera un déficit en la bolsa? %>
-      <div class="mb-4 form-check form-switch fs-5">
+      <div class="mb-4 form-check form-switch">
         <%= form.check_box :genera_deuda_en_bolsa, class: 'form-check-input', role: 'switch' %>
         <%= form.label :genera_deuda_en_bolsa, '¿Genera un déficit en la bolsa?', class: 'form-check-label fw-bold' %>
         <div class="form-text mt-1">Si está marcado, la ausencia genera un déficit en la bolsa ordinaria que el trabajador deberá recuperar (ej. Ausencia Injustificada).</div>


### PR DESCRIPTION
## Summary
- remove `fs-5` class from festivo form checkbox
- remove `fs-5` class from tipo de ausencia form checkboxes

## Testing
- `RBENV_VERSION=3.3.8 bundle exec rake test` *(fails: Your Ruby version is 3.3.8, but your Gemfile specified 3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_6875a8f98ae483278413fa5b0991f392