### PR TITLE
Ensure theoretical hours are used

### DIFF
--- a/app/javascript/controllers/previsualizacion_controller.js
+++ b/app/javascript/controllers/previsualizacion_controller.js
@@ -14,6 +14,13 @@ export default class extends Controller {
   }
 
   connect() {
+    // Si el campo de horas está vacío, inicializarlo con el valor teórico
+    this.element.querySelectorAll('input[name*="[horas_trabajadas]"]').forEach(input => {
+      if (!input.value && input.placeholder) {
+        input.value = input.placeholder
+      }
+    })
+
     // Realizar el primer cálculo al cargar la página
     this.recalcular()
   }


### PR DESCRIPTION
## Summary
- preload theoretical hours into hour inputs so they always count in totals

## Testing
- `bundle exec rails test:all` *(fails: 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68759fcdfd248327a77fc9690754a4fc