### PR TITLE
Fix variable usage in TipoContrato form partial

### DIFF
--- a/app/views/admin/tipo_contratos/edit.html.erb
+++ b/app/views/admin/tipo_contratos/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4">
   <h1>Editar Tipo de Contrato</h1>
 
-  <%= render 'form' %>
+  <%= render 'form', tipo_contrato: @tipo_contrato %>
 </div>

--- a/app/views/admin/tipo_contratos/new.html.erb
+++ b/app/views/admin/tipo_contratos/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4">
   <h1>Nuevo Tipo de Contrato</h1>
 
-  <%= render 'form' %>
+  <%= render 'form', tipo_contrato: @tipo_contrato %>
 </div>


### PR DESCRIPTION
## Summary
- pass `@tipo_contrato` as a local variable when rendering the form partial

## Testing
- `bundle exec rails test` *(fails: Can't find stylesheet to import)*

------
https://chatgpt.com/codex/tasks/task_e_687a56494e10832798e5eb645fbe48c6