### PR TITLE
Improve admin workers table spacing

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -116,3 +116,9 @@ form label {
   background-color: #e9ecef !important;
   color: #000;
 }
+
+/* --- Márgenes laterales para tablas de administración --- */
+.admin-table-margin {
+  margin-left: 40px;
+  margin-right: 40px;
+}

--- a/app/views/admin/trabajadores/index.html.erb
+++ b/app/views/admin/trabajadores/index.html.erb
@@ -13,7 +13,7 @@
 
 <div class="card">
   <div class="card-body p-0"> <%# p-0 para que la tabla ocupe todo el espacio de la tarjeta %>
-    <div class="table-responsive">
+    <div class="table-responsive admin-table-margin">
       <table class="table table-striped table-hover mb-0">
         <thead class="thead-light">
           <tr>


### PR DESCRIPTION
## Summary
- add a class to give side margins around the workers table
- style new class so the table isn't flush against the card edges

## Testing
- `bundle exec rails test` *(fails: rbenv: version `3.3.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a5b8da72483279d522fc39c703bff