### PR TITLE
Improve employee table layout

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -110,3 +110,18 @@ form label {
   justify-content: center;
   align-items: center;
 }
+
+/* Estilos específicos para el listado de empleados */
+.contenedor-empleados {
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+.contenedor-empleados thead th {
+  color: #000;
+}
+
+.contenedor-empleados th,
+.contenedor-empleados td {
+  padding: 10px 15px;
+}

--- a/app/views/admin/trabajadores/index.html.erb
+++ b/app/views/admin/trabajadores/index.html.erb
@@ -11,39 +11,25 @@
   </div>
 </div>
 
-<div class="card">
-  <div class="card-body p-0"> <%# p-0 para que la tabla ocupe todo el espacio de la tarjeta %>
-    <div class="table-responsive">
-      <table class="table table-striped table-hover mb-0">
-        <thead class="thead-light">
-          <tr>
-            <th class="py-3 px-4">Nombre</th>
-            <th class="py-3 px-4">Tipo de Contrato</th>
-            <th class="py-3 px-4">Jornada Semanal</th>
-            <th class="py-3 px-4">Saldo Horas</th>
-            <th class="text-end py-3 px-4">Acciones</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @trabajadores.each do |trabajador| %>
+<div class="contenedor-empleados">
+  <div class="card">
+    <div class="card-body p-0"> <%# p-0 para que la tabla ocupe todo el espacio de la tarjeta %>
+      <div class="table-responsive">
+        <table class="table table-striped table-hover mb-0">
+          <thead class="thead-light">
             <tr>
-              <td class="py-3 px-4 align-middle"><%= trabajador.nombre %></td>
-              <td class="py-3 px-4 align-middle"><%= trabajador.tipo_contrato&.nombre || 'N/A' %></td>
-              <td class="py-3 px-4 align-middle"><%= number_to_human(trabajador.jornada_semanal_actual, precision: 2, strip_insignificant_zeros: true) %> h</td>
-              <td class="py-3 px-4 align-middle">
-                <% saldo = trabajador.bolsa_horas_saldo %>
-                <%= number_with_precision(
-                  (saldo&.saldo_bolsa_horas || 0) + (saldo&.saldo_bolsa_festivos || 0) + (saldo&.saldo_bolsa_libranza || 0),
-                  precision: 2
-                ) %>
-              </td>
-              <td class="text-end py-3 px-4 align-middle">
-                <%= link_to 'Ver Ficha', admin_trabajador_path(trabajador), class: 'btn btn-sm btn-primary' %>
-              </td>
+              <th class="py-3 px-4">Nombre</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% @trabajadores.each do |trabajador| %>
+              <tr>
+                <td class="py-3 px-4 align-middle"><%= trabajador.nombre %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap employee index table in a new container
- display only the employee name column
- style employees table margins and padding

## Testing
- `bin/rails test` *(fails: rbenv version `3.3.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a76940610832788395203eb2b8471