### PR TITLE
Implement fixed header bar

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -110,3 +110,27 @@ form label {
   justify-content: center;
   align-items: center;
 }
+
+/* --- Cabecera Fija Superior --- */
+.fixed-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1030;
+  background-color: #5F9EA0;
+  color: #fff;
+  padding: 0.5rem 1rem;
+}
+
+.fixed-header .app-title {
+  color: #fff;
+}
+
+.fixed-header .header-actions .btn {
+  margin-left: 0.5rem;
+}
+
+body.with-fixed-header {
+  padding-top: 56px;
+}

--- a/app/views/fichajes/semanal.html.erb
+++ b/app/views/fichajes/semanal.html.erb
@@ -48,7 +48,8 @@
       .preview-cell strong { font-family: monospace; font-size: 1.1em; padding: 2px 4px; border-radius: 3px; background-color: #e9ecef; }
     </style>
 </head>
-<body>
+<body class="with-fixed-header">
+    <%= render 'layouts/header' %>
     <div class="container content-box"
          data-controller="semanal"
          data-semanal-year-value="<%= @anio_seleccionado %>"

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,12 @@
+<nav class="navbar navbar-dark fixed-header">
+  <div class="container-fluid d-flex justify-content-between align-items-center">
+    <span class="navbar-brand mb-0 h1 app-title">Control Horario</span>
+    <div class="header-actions d-flex align-items-center">
+      <% if logged_in? %>
+        <span class="me-3">Usuario: <strong><%= current_user.email %></strong></span>
+        <%= link_to 'Volver al Menú', root_path, class: 'btn btn-light me-2' %>
+        <%= link_to 'Cerrar Sesión', logout_path, data: { turbo_method: :delete }, class: 'btn btn-outline-light' %>
+      <% end %>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,7 +14,8 @@
   <%= javascript_importmap_tags %>
 </head>
 
-<body>
+<body class="with-fixed-header">
+  <%= render 'layouts/header' %>
   <div class="container mt-4">
     <div class="content-box">
       <% if notice %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,10 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <%= yield %>
+  <body class="with-fixed-header">
+    <%= render 'layouts/header' %>
+    <main>
+      <%= yield %>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new `_header` partial with application name, user info and navigation buttons
- include the header in `application`, `admin` and weekly report layouts
- apply the header to the standalone weekly page
- style header in `custom.css` so it remains fixed at the top

## Testing
- `bundle exec rake test` *(fails: Ruby 3.3.3 missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a76f593bc8327b6bf7b2c292aff9c